### PR TITLE
Fix wss protocol

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "rollup -c -w",
     "start": "sirv public --no-clear",
     "check": "svelte-check --tsconfig ./tsconfig.json",
-    "test": "jest"
+    "test": "jest",
+    "format": "prettier --write '**/*.{svelte,ts}'"
   },
   "devDependencies": {
     "@babel/core": "^7.18.2",

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -45,12 +45,11 @@
     }
 
     function dial() {
-        let conn: WebSocket;
-        try {
-            conn = new WebSocket(`wss://${location.host}/subscribe`);
-        } catch (e) {
-            conn = new WebSocket(`ws://${location.host}/subscribe`);
-        }
+        let wsUrl =
+            location.protocol === 'https:'
+                ? `wss://${location.host}/subscribe`
+                : `ws://${location.host}/subscribe`;
+        let conn: WebSocket = new WebSocket(wsUrl);
 
         conn.addEventListener('close', (ev) => {
             if (ev.code !== 1001) {


### PR DESCRIPTION
`new WebSocket()` does not throw an error which the current
logic seems to expect. Some background [here](https://stackoverflow.com/a/25781815).

We can handle it by adding `onerror` callback but choosing
the protocol based on `location.protocol` seems to be cleaner.
