### PR TITLE
refractor: Move config modal code into modal component

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -42,34 +42,6 @@
 
     let filterPorts: number[] = [];
 
-    function defineMessages(event: any) {
-        let chosenValue = event.target[0].value;
-        let presentMessages = messages.length;
-
-        if (chosenValue <= 0) {
-            return;
-        }
-
-        if (chosenValue < presentMessages) {
-            messages = messages.slice(messages.length - chosenValue, messages.length);
-        }
-
-        noOfMessages = chosenValue;
-    }
-
-    function toggleMode(event: any) {
-        let chosenMode = event.target.id;
-
-        if (chosenMode == 'dev') {
-            isDevOn = true;
-        } else if (chosenMode == 'prod') {
-            isDevOn = false;
-            if (conn != null) {
-                conn.close();
-            }
-        }
-    }
-
     function addMessage(message: messageType) {
         if (message.dstPort === null || !filterPorts.includes(message.dstPort)) {
             messages.push(message);
@@ -141,28 +113,7 @@
     });
 </script>
 
-<Modal bind:showModal>
-    <form id="configmodal" on:submit|preventDefault={defineMessages}>
-        <p>Number of messages</p>
-        <input
-            id="messages-input-box"
-            type="number"
-            min="0"
-            bind:value={inputMessages}
-            class:error-state={inputMessages <= 0}
-        />
-        <p>Mode</p>
-        <label>
-            <input type="radio" name="radio-group" id="dev" on:click={toggleMode} />
-            Development
-        </label>
-        <label>
-            <input type="radio" name="radio-group" checked id="prod" on:click={toggleMode} />
-            Production
-        </label>
-        <button disabled={inputMessages < 0} type="submit">Apply</button>
-    </form>
-</Modal>
+<Modal bind:showModal />
 
 <header class="site-header">
     <b>Ochi</b>: find me at

--- a/src/Modal.svelte
+++ b/src/Modal.svelte
@@ -1,7 +1,40 @@
-<script>
+<script lang="ts">
     export let showModal;
 
+    let messages: messageType[] = [];
+
+    let noOfMessages: number;
     let dialog;
+    let inputMessages: number;
+    let isDevOn: boolean;
+    let conn: WebSocket;
+    function defineMessages(event: any) {
+        let chosenValue = event.target[0].value;
+        let presentMessages = messages.length;
+
+        if (chosenValue <= 0) {
+            return;
+        }
+
+        if (chosenValue < presentMessages) {
+            messages = messages.slice(messages.length - chosenValue, messages.length);
+        }
+
+        noOfMessages = chosenValue;
+    }
+
+    function toggleMode(event: any) {
+        let chosenMode = event.target.id;
+
+        if (chosenMode == 'dev') {
+            isDevOn = true;
+        } else if (chosenMode == 'prod') {
+            isDevOn = false;
+            if (conn != null) {
+                conn.close();
+            }
+        }
+    }
 
     $: if (dialog && showModal) dialog.showModal();
 </script>
@@ -12,6 +45,26 @@
     on:click|self={() => dialog.close()}
 >
     <div on:click|stopPropagation>
+        <form id="configmodal" on:submit|preventDefault={defineMessages}>
+            <p>Number of messages</p>
+            <input
+                id="messages-input-box"
+                type="number"
+                min="0"
+                bind:value={inputMessages}
+                class:error-state={inputMessages <= 0}
+            />
+            <p>Mode</p>
+            <label>
+                <input type="radio" name="radio-group" id="dev" on:click={toggleMode} />
+                Development
+            </label>
+            <label>
+                <input type="radio" name="radio-group" checked id="prod" on:click={toggleMode} />
+                Production
+            </label>
+            <button disabled={inputMessages < 0} type="submit">Apply</button>
+        </form>
         <slot />
         <button on:click={() => dialog.close()}>Close</button>
     </div>


### PR DESCRIPTION
Moved Config modal code from 'App.svelte' to 'Modal.svelte' along with its required dependencies. Requesting Code Review.